### PR TITLE
Ensure that running telepresence daemons are stopped

### DIFF
--- a/emojivoto-web-app/js/setup_dev_env.sh
+++ b/emojivoto-web-app/js/setup_dev_env.sh
@@ -163,10 +163,13 @@ install_upgrade_telepresence() {
         install_telepresence=true
         echo "Installing Telepresence"
     else
+        # Ensure that running telepresence daemons are stopped. A running daemon
+        # has its current working directory set to the directory where it was first
+        # started, and since the KUBECONFIG is set to a relative directory in this
+        # script, a previously started daemon might resolve it incorrectly.
+        _=$(telepresence quit -ur)
         if telepresence version|grep upgrade >/dev/null 2>&1; then
             install_telepresence=true
-            # daemon and client need to have same version
-            _=$(telepresence quit)
             echo "Upgrading Telepresence"
         else
             echo "Telepresence already installed"


### PR DESCRIPTION
The `setup_dev_env.sh` script sets `KUBECONFIG` to a relative path. This
means that it will be resolved by the Telepresence user daemon when it
connects to the cluster. If telepresence was started in some other
directory prior to running this example, then the user daemon will
resolve the path incorrectly and fail to connect, and the connector.log
contains the message:
```
unable to track k8s cluster: stat ./emojivoto_k8s_context.yaml: no such file or directory
```

This commit adds a `telepresence quit -ur` call prior to calling
`telepresence version`, thereby ensuring that the daemons are stopped.