### PR TITLE
Use Telepresence 2.5.8

### DIFF
--- a/emojivoto-web-app/js/setup_dev_env.sh
+++ b/emojivoto-web-app/js/setup_dev_env.sh
@@ -177,7 +177,7 @@ install_upgrade_telepresence() {
         fi
     fi    
     if [ $install_telepresence = true ]; then
-        sudo curl -fL https://app.getambassador.io/download/tel2/${OS}/${ARCH}/latest/telepresence -o /usr/local/bin/telepresence
+        sudo curl -fL https://app.getambassador.io/download/tel2/${OS}/${ARCH}/2.5.8/telepresence -o /usr/local/bin/telepresence
         sudo chmod a+x /usr/local/bin/telepresence
         send_telemetry "telepresenceInstalled"
     fi


### PR DESCRIPTION
### What
 Use TP 2.5.8 
### Why?
As a short-term solution, because the tour is not working using the latest version (2.6.2) and we have a presentation tomorrow.

We noticed that following the intermediate tour from the cloud, when we use the version 2.6.2 the script creates the intercept (preview url) but seems that the traffic is not redirected to our local machine. In version 2.5.8 is working as we expect.