### PR TITLE
Tweak the demo script to make it run in docker mode only

### DIFF
--- a/emojivoto-web-app/js/setup_dev_env.sh
+++ b/emojivoto-web-app/js/setup_dev_env.sh
@@ -131,7 +131,7 @@ run_dev_container() {
     fi
 
     # run the dev container, exposing 8081 gRPC port and volume mounting code directory
-    docker run -d -p8083:8083 -p8080:8080 --name ambassador-demo --pull always --rm -it -v $(pwd):/opt/emojivoto/emojivoto-web-app/js datawire/intermediate-tour
+    docker run -d --name ambassador-demo --pull always --network=container:tp-default --rm -it -v $(pwd):/opt/emojivoto/emojivoto-web-app/js datawire/intermediate-tour
     CONTAINER_ID=$(docker ps --filter 'name=ambassador-demo' --format '{{.ID}}')
     send_telemetry "devContainerStarted"    
 }
@@ -198,7 +198,8 @@ connect_local_dev_env_to_remote() {
     telepresence quit
     telepresence helm upgrade --team-mode
     telepresence login --apikey=${AMBASSADOR_API_KEY}
-    telepresence connect
+    telepresence quit -s
+    telepresence connect --docker
     
     interceptName=$(kubectl get rs -n emojivoto --selector=app=web-app --no-headers -o custom-columns=":metadata.name")
     telepresence intercept ${interceptName} -n ${EMOJIVOTO_NS} --service web-app --port 8083:80 --ingress-port 80 --ingress-host ${svcName}.ambassador --ingress-l5 ${svcName}.ambassador
@@ -234,9 +235,9 @@ has_cli
 set_os_arch
 check_init_config
 install_upgrade_telepresence
-run_dev_container
 connect_to_k8s
 connect_local_dev_env_to_remote
+run_dev_container
 open_editor
 display_instructions_to_user
 

--- a/emojivoto-web-app/js/setup_dev_env.sh
+++ b/emojivoto-web-app/js/setup_dev_env.sh
@@ -202,7 +202,7 @@ connect_local_dev_env_to_remote() {
     telepresence connect --docker
     
     interceptName=$(kubectl get rs -n emojivoto --selector=app=web-app --no-headers -o custom-columns=":metadata.name")
-    telepresence intercept ${interceptName} -n ${EMOJIVOTO_NS} --service web-app --port 8083:80 --ingress-port 80 --ingress-host ${svcName}.ambassador --ingress-l5 ${svcName}.ambassador
+    telepresence intercept ${interceptName} --docker --context tp-default -n ${EMOJIVOTO_NS} --service web-app --port 8083:80 --ingress-port 80 --ingress-host ${svcName}.ambassador --ingress-l5 ${svcName}.ambassador
 
     telOut=$?
     if [ $telOut != 0 ]; then

--- a/emojivoto-web-app/js/setup_dev_env.sh
+++ b/emojivoto-web-app/js/setup_dev_env.sh
@@ -120,7 +120,7 @@ check_init_config() {
 }
 
 run_dev_container() {
-    display_step 4
+    display_step 6
     echo 'Configuring development container. This container encapsulates all the dependencies needed to run the emojivoto-web-app locally.'
     echo 'This may take a few moments to download and start.'
 
@@ -137,7 +137,7 @@ run_dev_container() {
 }
 
 connect_to_k8s() {
-    display_step 5
+    display_step 4
     echo 'Getting KUBECONFIG from demo cluster'
     demo_cluster_url="https://auth.datawire.io/api/democlusters/telepresence-demo/config"
     if [[ "$SYSTEMA_ENV" == "staging" ]]; then
@@ -185,7 +185,7 @@ install_upgrade_telepresence() {
 
 connect_local_dev_env_to_remote() {
     export KUBECONFIG=./emojivoto_k8s_context.yaml
-    display_step 6
+    display_step 5
     echo 'Connecting local development environment to remote K8s cluster'
 
     svcName="ambassador"

--- a/emojivoto-web-app/js/setup_dev_env.sh
+++ b/emojivoto-web-app/js/setup_dev_env.sh
@@ -202,7 +202,7 @@ connect_local_dev_env_to_remote() {
     telepresence connect --docker
     
     interceptName=$(kubectl get rs -n emojivoto --selector=app=web-app --no-headers -o custom-columns=":metadata.name")
-    telepresence intercept ${interceptName} --docker --context tp-default -n ${EMOJIVOTO_NS} --service web-app --port 8083:80 --ingress-port 80 --ingress-host ${svcName}.ambassador --ingress-l5 ${svcName}.ambassador
+    telepresence intercept ${interceptName} --docker --context default -n ${EMOJIVOTO_NS} --service web-app --port 8083:80 --ingress-port 80 --ingress-host ${svcName}.ambassador --ingress-l5 ${svcName}.ambassador
 
     telOut=$?
     if [ $telOut != 0 ]; then


### PR DESCRIPTION
Currently the emojivoto demo runs locally on your machine, and as such requires Root access.

This PR tweaks the code a little to take advantage of the "docker" mode of telepresence, and then don't require any root access to run the demo.

Basically running all the commands requiering a root access with the `--docker` parameter does the trick, but also running the demo container this way:

```cli
docker run -d --name ambassador-demo --pull always --network=container:tp-default --rm -it -v $(pwd):/opt/emojivoto/emojivoto-web-app/js datawire/intermediate-tour
```

```--network=container:tp-default``` means use the same network interface than the tp-default container which is hosting the demon.

To test, juse do the developper demo in the cloud app, but when it asks to clone emojivoto, clone with : 

```cli
git clone git@github.com:datawire/emojivoto.git --branch knlambert/run-demo-with-docker
```