### PR TITLE
add powershell script

### DIFF
--- a/emojivoto-web-app/js/setup_dev_env.ps1
+++ b/emojivoto-web-app/js/setup_dev_env.ps1
@@ -58,7 +58,7 @@ function has_cli {
         $meet_requirements=$false
     }
     if (-not (docker stats --no-stream 2> $null)) {
-        Write-Host "El demonio de Docker no está ejecutándose"
+        Write-Host "The Docker daemon isn't running"
         $meet_requirements=$false
     }
     if(-not $meet_requirements){
@@ -74,7 +74,6 @@ function set_os_arch{
         Write-Host "Unsupported architecture $Env:PROCESSOR_ARCHITECTURE"
         exit 
     }
-    
 }
 
 function check_init_config{
@@ -192,7 +191,7 @@ function display_instructions_to_user () {
     Write-Host 'INSTRUCTIONS FOR DEVELOPMENT'
     Write-Host '============================'
     Write-Host 'To set the correct Kubernetes context on this shell, please execute:'
-    Write-Host 'export KUBECONFIG=./emojivoto_k8s_context.yaml'
+    Write-Host 'New-Item -Path Env:\KUBECONFIG -Value=./emojivoto_k8s_context.yaml'
 }
 
 use_telemetry


### PR DESCRIPTION
This PR adds a new script to run in Windows and Powershell. We only support running the intermediate tour in the application using Linux and MacOs. This script is the first iteration to support Windows in the intermediate tour.

In order to test the pr you need the following:
- Windows(only windows 10 tested)
- kubectl
- Ability to use Powershell as an administrator
- Access to `app.getambassador.io`
- it is assuming that you doesn't have telepresence installed

Kown issues
- Telepresence is not updatable from the script
- If the user cancels the telepresence installation, the script is going to continue

Testing:
1. Go to app.getambassador.io and start the tour
<img width="1046" alt="image" src="https://github.com/datawire/emojivoto/assets/42355868/08862df2-e97e-4eb3-9ce3-f719b57570c1">

2. Click on `Don't have a cluster? get a free one!`

4. Follow the instruction in the tour until step 3: Run the script
<img width="715" alt="image" src="https://github.com/datawire/emojivoto/assets/42355868/8ad0b31a-5fb1-4405-91b6-161d8503913c">

5. Using power shell as administrator move the branch of this PR:
```git checkout agv/dev/windows_script```

6. Then set the environment variable with the `AMBASSADOR_API_KEY` provided in the tour
```New-Item -Path Env:\AMBASSADOR_API_KEY -Value NDFSFADS....```

7.  Then run the script
```.\setup_dev_env.sp1```
